### PR TITLE
v0.2.0 RC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## 0.2.0 - 2015-07-08
+### Changed
+- [BREAKING CHANGE] Middleware arguments have been swapped to conform to the fetch APIs. See the [documentation](https://github.com/blimmer/node-ember-cli-deploy-redis/blob/v0.2.0/README.md#example) for info.
+
 ## 0.1.1 - 2015-06-02
 ### Changed
 - Test objects exposed. See the [documentation](https://github.com/blimmer/node-ember-cli-deploy-redis/blob/v0.1.1/README.md#testing) for info.

--- a/README.md
+++ b/README.md
@@ -24,12 +24,12 @@ var express = require('express');
 var app = express();
 
 var nodeEmberCliDeployRedis = require('node-ember-cli-deploy-redis');
-app.use('/*', nodeEmberCliDeployRedis({
+app.use('/*', nodeEmberCliDeployRedis('myapp', {
   host: 'redis.example.org',
   port: 6929,
   password: 'passw0rd!',
   database: 0
-}, 'myapp'));
+}));
 ```
 
 ### Custom Fetch Method
@@ -61,11 +61,11 @@ app.get('/', function(req, res) {
 Check out [location-aware-ember-server](https://github.com/blimmer/location-aware-ember-server) for a running example.
 
 ## Documentation
-### `nodeEmberCliDeployRedis(connectionInfo, appName, options)` (middleware constructor)
-* connectionInfo (required) - the configuration to connect to redis.  
-   internally, this library uses [then-redis](https://github.com/mjackson/then-redis), so pass a configuration supported by then-redis. please see their README for more information.
+### `nodeEmberCliDeployRedis(appName, connectionInfo, options)` (middleware constructor)
 * appName (required) - the application name, specified for ember deploy  
    the keys in redis are prefaced with this name. For instance, if your redis keys are `my-app:current`, you'd pass `my-app`.
+* connectionInfo (required) - the configuration to connect to redis.  
+   internally, this library uses [then-redis](https://github.com/mjackson/then-redis), so pass a configuration supported by then-redis. please see their README for more information.
 * options (optional) - a hash of params to override [the defaults](https://github.com/blimmer/node-ember-cli-deploy-redis/blob/develop/README.md#options)
 
 ### `fetchIndex(request, appName, connectionInfo, options)`

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
-var Bluebird  = require('bluebird');
+'use strict';
+
+var Bluebird = require('bluebird');
 var fetchIndex = require('./fetch');
 
-module.exports = function (connectionInfo, appName, opts) {
+module.exports = function (appName, connectionInfo, opts) {
   return function(req, res) {
     return new Bluebird(function (resolve, reject) {
       fetchIndex(req, appName, connectionInfo, opts).then(function(indexHtml) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ember-cli-deploy-redis",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "An ExpressJS middleware to serve EmberJS apps deployed by ember-cli-deploy",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
## BREAKING CHANGES

An inconsistency between the fetch api and middleware was fixed.

In 0.1.x, you used the middleware like this

``` javascript
app.use('/*', nodeEmberCliDeployRedis({
  host: 'redis.example.org',
  port: 6929,
  password: 'passw0rd!',
  database: 0
}, 'myapp'));
```

However, this was inconsistent with the `fetchIndex` method as noted by @knownasilya . To transition, please change your middleware declaration like this

``` javascript
app.use('/*', nodeEmberCliDeployRedis('myapp', {
  host: 'redis.example.org',
  port: 6929,
  password: 'passw0rd!',
  database: 0
}));
```
