### PR TITLE
Change key name retrieved to correspond to new version of ember-cli-deploy-redis

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -54,7 +54,7 @@ var fetchIndex = function (req, appName, connectionInfo, passedOpts) {
   }
 
   return retrieveIndexKey().then(function(indexkey){
-    return redisClient.get(indexkey);
+    return redisClient.get(appName + ":" + indexkey);
   }).then(function(indexHtml){
       if (!indexHtml) { throw new Error(); }
       return indexHtml;
@@ -62,7 +62,7 @@ var fetchIndex = function (req, appName, connectionInfo, passedOpts) {
     if (err.name === 'EmberCliDeployError') {
       throw err;
     } else {
-      throw new EmberCliDeployError("There's no " + indexkey + " revision. The site is down.", !customIndexKeyWasSpecified);
+      throw new EmberCliDeployError("There's no " + appName + ":" + indexkey + " revision. The site is down.", !customIndexKeyWasSpecified);
     }
   });
 };


### PR DESCRIPTION
The latest version of `ember-cli-deploy-redis` has key/values like that (from their README):

```
127.0.0.1:6379> KEYS *
1) my-app:index:revisions
2) my-app:index:9ab2021411f0cbc5ebd5ef8ddcd85cef
3) my-app:index:499f5ac793551296aaf7f1ec74b2ca79
4) my-app:index:f769d3afb67bd20ccdb083549048c86c
5) my-app:index:current

127.0.0.1:6379> GET my-app:index:current
"f769d3afb67bd20ccdb083549048c86c"
```

Note that I didn't add the `:index` as we can do it in the appName param. This should probably be another issue, either to change the documentation, or to add it in the code.

I only added the `my-app:index:` from the revision value retrieved from `my-app:index:current`, as it does not indicate the complete key name anymore.
