### PR TITLE
Remove `database` deprecation and fallback.

### DIFF
--- a/fetch.js
+++ b/fetch.js
@@ -31,19 +31,6 @@ var _initialize = function (connectionInfo, passedOpts) {
   opts = _getOpts(passedOpts);
   var config = connectionInfo ? connectionInfo : defaultConnectionInfo;
 
-  // ioRedis uses the `db` param rather than `database`.
-  // This block keeps the existing API compatible.
-  if (config.database) {
-    console.warn(
-      "[DEPRECATION] " +
-      "You passed a key called 'database' to node-ember-cli-deploy-redis. " +
-      "Please replace with 'db'. This fallback will be removed in the future."
-    );
-
-    config.db = config.database;
-    delete config.database;
-  }
-
   redisClient = new ioRedis(config);
 
   if (opts.memoize === true) {

--- a/test/fetch-test.js
+++ b/test/fetch-test.js
@@ -66,45 +66,6 @@ describe('fetch', function() {
         expect(callArg).to.be.a('string');
         expect(callArg).to.equal(configString);
       });
-
-      // TODO: remove this after people have a chance to fix their apps
-      // change was introduced in 0.4.x
-      describe('database vs. db param', function() {
-        var consoleStub;
-        beforeEach(function() {
-          consoleStub = sandbox.stub(console, 'warn');
-        });
-
-        it('translates database to db', function() {
-          var configObj = {
-            database: 1
-          };
-
-          _initialize(configObj);
-
-          expect(ioRedisInitStub.calledOnce).to.be.true;
-          expect(ioRedisInitStub.calledWithNew()).to.be.true;
-          expect(ioRedisInitStub.firstCall.args.length).to.equal(1);
-
-          var callArg = ioRedisInitStub.firstCall.args[0];
-
-          expect(callArg).to.be.an('object');
-          expect(callArg).to.not.have.key('database');
-          expect(callArg.db).to.equal(1);
-        });
-
-        it('warns the developer of this deprecation', function() {
-          var configObj = {
-            database: 1
-          };
-
-          _initialize(configObj);
-
-          var warning = consoleStub.firstCall.args[0];
-          expect(warning).to.include('DEPRECATION');
-          expect(warning).to.include("replace with 'db'");
-        });
-      });
     });
 
     describe('memoization', function() {


### PR DESCRIPTION
I'm prepping an upgrade release and, with that, will release a
non-backwards-compatible version. Therefore, this deprecation will be
removed.