### PR TITLE
[BREAKING CHANGE] Pass error back to app from middleware instead of rendering a `500`

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,13 +4,13 @@ const Bluebird = require('bluebird');
 const fetchIndex = require('./fetch');
 
 module.exports = function (keyPrefix, connectionInfo, opts) {
-  return function(req, res) {
+  return function(req, res, next) {
     return new Bluebird(function (resolve, reject) {
       fetchIndex(req, keyPrefix, connectionInfo, opts).then(function(indexHtml) {
         res.status(200).send(indexHtml);
         resolve();
       }).catch(function(err) {
-        res.status(500).send(err);
+        next(err);
         reject();
       });
     });

--- a/index.js
+++ b/index.js
@@ -11,7 +11,6 @@ module.exports = function (keyPrefix, connectionInfo, opts) {
         resolve();
       }).catch(function(err) {
         next(err);
-        reject();
       });
     });
   };

--- a/index.js
+++ b/index.js
@@ -5,7 +5,7 @@ const fetchIndex = require('./fetch');
 
 module.exports = function (keyPrefix, connectionInfo, opts) {
   return function(req, res, next) {
-    return new Bluebird(function (resolve, reject) {
+    return new Bluebird(function (resolve) {
       fetchIndex(req, keyPrefix, connectionInfo, opts).then(function(indexHtml) {
         res.status(200).send(indexHtml);
         resolve();

--- a/smoke-test/run.sh
+++ b/smoke-test/run.sh
@@ -20,7 +20,7 @@ _start-express-app() {
   echo "Starting express app..."
   pushd "$SCRIPT_DIR/express"
   npm install --no-package-lock
-  npm start &
+  NODE_ENV=production npm start &
   EXPRESS_APP_PID=$!
 
   echo "Waiting for express app to start up..."

--- a/smoke-test/test.bats
+++ b/smoke-test/test.bats
@@ -18,3 +18,9 @@ setup() {
   assert_success
   assert_output '<html><body>this is def456</body></html>'
 }
+
+@test "it returns a 500 when the specified key is not found in redis" {
+  run curl -s localhost:3000/?index_key=ghi789
+  assert_success
+  assert_output --partial "Internal Server Error"
+}

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -43,16 +43,15 @@ describe('express middleware', function() {
   });
 
   describe('failure', function() {
-    it('returns a 500 and the error', function(done) {
+    it('calls the `next` function with the error', function(done) {
+      var nextStub = sandbox.stub();
       var error = new EmberCliDeployError();
       fetchIndexStub.returns(Bluebird.reject(error));
 
-      middleware()(req, res).then(function() {
+      middleware()(req, res, nextStub).then(function() {
         done('Promise should not have resolved');
       }).catch(function() {
-        expect(res.statusCode).to.equal(500);
-        var data = res._getData();
-        expect(data).to.equal(error);
+        expect(nextStub).to.have.been.calledOnceWith(error)
         done();
       });
     });

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -44,15 +44,17 @@ describe('express middleware', function() {
 
   describe('failure', function() {
     it('calls the `next` function with the error', function(done) {
-      var nextStub = sandbox.stub();
       var error = new EmberCliDeployError();
       fetchIndexStub.returns(Bluebird.reject(error));
 
-      middleware()(req, res, nextStub).then(function() {
-        done('Promise should not have resolved');
-      }).catch(function() {
-        expect(nextStub).to.have.been.calledOnceWith(error)
+      function nextExpectation() {
+        expect(arguments).to.have.length(1);
+        expect(arguments[0]).to.equal(error);
         done();
+      }
+
+      middleware()(req, res, nextExpectation).then(function() {
+        done('Promise should not have resolved');
       });
     });
   });


### PR DESCRIPTION
Previously this middleware would explicitly render an error if a requested revision key was not found. However, this prevented users from choosing their own behavior when an error is encountered.

This change will now let the [default express error handler](https://expressjs.com/en/guide/error-handling.html#the-default-error-handler), or a custom-defined error handler manage this behavior.

If you'd like to retain the existing behavior, write a small middleware function such as:

```javascript
app.use(function (err, req, res, next) {
  res.status(500).send(err);
});
```

See [the documentation](https://expressjs.com/en/guide/error-handling.html#writing-error-handlers) for more information on writing an error handler.