### PR TITLE
Use native Promise instead of Bluebird.

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Arguments
 
 Returns
 
-* a [Promise](https://github.com/petkaantonov/bluebird/blob/master/API.md#core)
+* a `Promise`
    when resolved, it returns the requested `index.html` string
    when failed, it returns an [EmberCliDeployError](https://github.com/blimmer/node-ember-cli-deploy-redis/blob/develop/errors/ember-cli-deploy-error.js).
 

--- a/fetch.js
+++ b/fetch.js
@@ -1,4 +1,3 @@
-const Bluebird  = require('bluebird');
 const _defaultsDeep = require('lodash/defaultsDeep');
 
 const EmberCliDeployError = require('./errors/ember-cli-deploy-error');
@@ -60,7 +59,7 @@ function fetchIndex(req, keyPrefix, connectionInfo, passedOpts) {
   let customIndexKeyWasSpecified = !!indexkey;
   function retrieveIndexKey(){
     if (indexkey) {
-      return Bluebird.resolve(indexkey);
+      return Promise.resolve(indexkey);
     } else {
       return redisClient.get(keyPrefix + ":current").then(function(result){
         if (!result) { throw new Error(); }

--- a/index.js
+++ b/index.js
@@ -1,11 +1,10 @@
 'use strict';
 
-const Bluebird = require('bluebird');
 const fetchIndex = require('./fetch');
 
 module.exports = function (keyPrefix, connectionInfo, opts) {
   return function(req, res, next) {
-    return new Bluebird(function (resolve) {
+    return new Promise(function (resolve) {
       fetchIndex(req, keyPrefix, connectionInfo, opts).then(function(indexHtml) {
         res.status(200).send(indexHtml);
         resolve();

--- a/package-lock.json
+++ b/package-lock.json
@@ -206,11 +206,6 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
-    "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw=="
-    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "sinon-chai": "^3.3.0"
   },
   "dependencies": {
-    "bluebird": "^3.3.4",
     "ioredis": "^1.15.1",
     "lodash": "^4.7.0",
     "memoizee": "^0.3.9"

--- a/test/fetch-test.js
+++ b/test/fetch-test.js
@@ -6,7 +6,6 @@ const context = describe;
 
 const sinon =  require('sinon');
 const rewire = require('rewire');
-const Bluebird = require('bluebird');
 
 const fetchIndex = rewire('../fetch');
 
@@ -303,7 +302,7 @@ describe('fetch', function() {
 
     it('resolves the promise with the index html requested', function(done) {
       const currentHtmlString = '<html><body>1</body></html>';
-      Bluebird.all([
+      Promise.all([
         redis.set('myapp:index:current', 'abc123'),
         redis.set('myapp:index:abc123', currentHtmlString),
       ]).then(function(){
@@ -326,7 +325,7 @@ describe('fetch', function() {
           index_key: 'def456'
         }
       };
-      Bluebird.all([
+      Promise.all([
         redis.set('myapp:index:current', 'abc123'),
         redis.set('myapp:index:abc123', currentHtmlString),
         redis.set('myapp:index:def456', newDeployHtmlString)
@@ -344,7 +343,7 @@ describe('fetch', function() {
 
     it('memoizes results from redis when turned on', function(done) {
       const currentHtmlString = '<html><body>1</body></html>';
-      Bluebird.all([
+      Promise.all([
         redis.set('myapp:index:current', 'abc123'),
         redis.set('myapp:index:abc123', currentHtmlString),
         fetchIndex(basicReq, 'myapp:index', null, { memoize: true }),

--- a/test/helpers/test-api.js
+++ b/test/helpers/test-api.js
@@ -1,25 +1,23 @@
-var Bluebird = require('bluebird');
-
-var ioRedisClientApi = {
+const ioRedisClientApi = {
   _storage: {},
   get: function(key){
-    return Bluebird.resolve(this._storage[key]);
+    return Promise.resolve(this._storage[key]);
   },
   set: function(key, value){
     this._storage[key] = value;
-    return Bluebird.resolve(value);
+    return Promise.resolve(value);
   },
   del: function(key){
     delete this._storage[key];
-    return Bluebird.resolve();
+    return Promise.resolve();
   },
   flushall: function(){
     this._storage = {};
-    return Bluebird.resolve();
+    return Promise.resolve();
   }
 };
 
-var ioRedisApi = function() {
+const ioRedisApi = function() {
   return ioRedisClientApi;
 };
 

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -3,7 +3,6 @@ var { describe, before, beforeEach, afterEach, it } = require('mocha');
 
 var sinon     = require('sinon');
 var httpMocks = require('node-mocks-http');
-var Bluebird  = require('bluebird');
 var rewire    = require('rewire');
 
 var middleware = rewire('../index');
@@ -31,7 +30,7 @@ describe('express middleware', function() {
 
   describe('success', function() {
     it('returns a 200 and sends the html', function(done) {
-      fetchIndexStub.returns(Bluebird.resolve(htmlString));
+      fetchIndexStub.returns(Promise.resolve(htmlString));
 
       middleware()(req, res).then(function() {
         expect(res.statusCode).to.equal(200);
@@ -45,7 +44,7 @@ describe('express middleware', function() {
   describe('failure', function() {
     it('calls the `next` function with the error', function(done) {
       var error = new EmberCliDeployError();
-      fetchIndexStub.returns(Bluebird.reject(error));
+      fetchIndexStub.returns(Promise.reject(error));
 
       function nextExpectation() {
         expect(arguments).to.have.length(1);


### PR DESCRIPTION
Now that we only support Node 6+, we can use native promises, instead of
Bluebird